### PR TITLE
Fix header installation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -81,7 +81,7 @@ function install() {
     ssh-keyscan "${IP}" >> ~/.ssh/known_hosts
     ssh "${USER}@${IP}" "sudo apt-get update"
     # shellcheck disable=SC2029
-    ssh "${USER}@${IP}" "sudo apt-get install -y linux-headers-$(uname -r) linux-headers-generic"
+    ssh "${USER}@${IP}" 'sudo apt-get install -y linux-headers-$(uname -r) linux-headers-generic'
   done
 
   kubectl get nodes -o wide


### PR DESCRIPTION
Fix Linux header installation to resolve kernel version remotely instead of locally using single quotes around the ssh command becuase double quotes allow the sub-shell to be evaluated locally.

Related to https://github.com/MrSimonEmms/gitpod-k3s-guide/issues/1 